### PR TITLE
Introducing Word Weighting based on parent-child word relationship and recently used words [Proof of Concept]

### DIFF
--- a/Source/Includes/Conversions.ahk
+++ b/Source/Includes/Conversions.ahk
@@ -101,6 +101,8 @@ RebuildDatabase()
 	
 	CreateWordlistsTable()
 	
+	CreateWordRelationTable()
+	
 	SetDbVersion()
 	g_WordListDB.EndTransaction()
 		
@@ -249,7 +251,7 @@ CreateWordsTable(WordsTableName:="Words")
 {
 	global g_WordListDB
 	
-	IF not g_WordListDB.Query("CREATE TABLE " . WordsTableName . " (wordindexed TEXT NOT NULL, word TEXT NOT NULL, count INTEGER, worddescription TEXT, wordreplacement TEXT NOT NULL, PRIMARY KEY (word, wordreplacement) );")
+	IF not g_WordListDB.Query("CREATE TABLE " . WordsTableName . " (wordindexed TEXT NOT NULL, word TEXT NOT NULL, count INTEGER, worddescription TEXT, wordreplacement TEXT NOT NULL, lastused INTEGER DEFAULT (0), PRIMARY KEY (word, wordreplacement) );")
 	{
 		ErrMsg := g_WordListDB.ErrMsg()
 		ErrCode := g_WordListDB.ErrCode()
@@ -280,6 +282,19 @@ CreateWordlistsTable()
 		ErrMsg := g_WordListDB.ErrMsg()
 		ErrCode := g_WordListDB.ErrCode()
 		msgbox Cannot Create Wordlists Table - fatal error: %ErrCode% - %ErrMsg%
+		ExitApp
+	}
+}
+
+CreateWordRelationTable()
+{
+	global g_WordListDB
+	
+	IF not g_WordListDB.Query("CREATE TABLE WordRelations (word_minus1 TEXT NOT NULL, word TEXT NOT NULL, count INTEGER, lastused INTEGER DEFAULT (0), PRIMARY KEY ( word_minus1, word ));")
+	{
+		ErrMsg := g_WordListDB.ErrMsg()
+		ErrCode := g_WordListDB.ErrCode()
+		msgbox Cannot Create WordRelations Table - fatal error: %ErrCode% - %ErrMsg%
 		ExitApp
 	}
 }

--- a/Source/Includes/Sending.ahk
+++ b/Source/Includes/Sending.ahk
@@ -33,6 +33,7 @@ SendWord(WordIndex)
    }
    ; Update Typed Count
    UpdateWordCount(sending,0)
+   UpdateWordHierarchy(sending)
    SendFull(sending, ForceBackspace)   
    ClearAllVars(true)
    Return
@@ -64,7 +65,7 @@ SendFull(SendValue,ForceBackspace=false)
          {
             Capitalize := true
          }
-      } else if ( RegExMatch(Substr(g_Word, 1, 1), "S)[A-ZÀ-ÖØ-ß]") > 0 )
+      } else if ( RegExMatch(Substr(g_Word, 1, 1), "S)[A-ZÃ€-Ã–Ã˜-ÃŸ]") > 0 )
       {
          Capitalize := true
       }


### PR DESCRIPTION
## These changes introduce the following:
- Adds concept of parent-child word relationship and increasing weight of word based on that.
- Adds weighting for single words and for parent-child word relationship, based on how recently they were used.
- Adds new feature to bulk learn from words in the clipboard (can be used to quickly build parent-child word relationship).
- Small UI change to show Tray Balloon when force adding a new word to provide visual feedback.

## Notes:
This can be used with existing Wordlist.txt and WordlistLearned.txt files.  But existing WordlistLearned.db and WordlistLearned.db-journal files should be removed as there is no upgrade path coded yet.

## Still to do?
Should this be accepted, then a new database version needs to added and upgrade functions added.
A new delete functionality would need to be added to take care of deleting word relationships when a single word is deleted.